### PR TITLE
add syntax after 2018 march

### DIFF
--- a/grammars/sql-bigquery.cson
+++ b/grammars/sql-bigquery.cson
@@ -34,7 +34,9 @@
         'name': 'keyword.other.DML.sql'
       '5':
         'name': 'entity.name.function.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?|drop)\\s+(table|view)\\b(?:\\s+(if(?:\\s+not)?\\s+exists)\\b)?)(?:\\s+(`?)((?:[\\w\\-]+\\.)?(?:\\w+\\.)?[\\w\\*]+)\\4)?'
+      '6':
+        'name': 'invalid.illegal.table.delimiter.sql'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?|drop)\\s+(table|view)\\b(?:\\s+(if(?:\\s+not)?\\s+exists)\\b)?)(?:\\s+(`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}\\*]+)\\4)?'
     'name': 'meta.create.sql'
   }
   {
@@ -55,8 +57,10 @@
       '3':
         'name': 'entity.name.function.table.standard.sql'
       '4':
+        'name': 'invalid.illegal.table.delimiter.sql'
+      '5':
         'name': 'variable.parameter.table.partition_decorator.sql'
-    'match': '(?i:^\\b(insert(?:\\s+into)?)(?:\\s+(`?)((?:[\\w\\-]+\\.)?(?:\\w+\\.)?\\w+)(\\*|\\$\\w+)?\\2)?)'
+    'match': '(?i:^\\b((?:insert|merge)(?:\\s+into)?)(?:\\s+(`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\2)?)'
     'name': 'meta.create.DML.insert.sql'
   }
   {
@@ -66,12 +70,16 @@
       '4':
         'name': 'entity.name.function.table.standard.sql'
       '5':
-        'name': 'variable.parameter.table.partition_decorator.sql'
+        'name': 'invalid.illegal.table.delimiter.sql'
       '6':
-        'name': 'entity.name.function.table.partition_decorator.legacy.sql'
+        'name': 'variable.parameter.table.partition_decorator.sql'
       '7':
+        'name': 'entity.name.function.table.partition_decorator.legacy.sql'
+      '8':
+        'name': 'invalid.illegal.table.delimiter.sql'
+      '9':
         'name': 'variable.parameter.table.legacy.sql'
-    'match': '(?i)(from|join|delete\\s+from|delete(?!\\s+from)|update)\\s+((`?)((?:[\\w\\-]+\\.)?(?:\\w+\\.)?\\w+)(\\*|\\$\\w+)?\\3?|\\[((?:[\\w\\-]+\\:)?(?:\\w+\\.)?\\w+)(\\*|\\$\\w+)?\\])'
+    'match': '(?i)(from|join|delete\\s+from|delete(?!\\s+from)|update|using)\\s+((`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\3?|\\[((?:[\\w\\-\\{\\}]+(?:\\:|(\\.)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\])'
     'name': 'meta.create.from.sql'
   }
   {
@@ -79,13 +87,24 @@
       '2':
         'name': 'entity.name.function.table.standard.sql'
       '3':
-        'name': 'variable.parameter.table.partition_decorator.sql'
+        'name': 'invalid.illegal.table.delimiter.sql'
       '4':
-        'name': 'entity.name.function.table.partition_decorator.legacy.sql'
+        'name': 'variable.parameter.table.partition_decorator.sql'
       '5':
+        'name': 'entity.name.function.table.partition_decorator.legacy.sql'
+      '6':
+        'name': 'invalid.illegal.table.delimiter.sql'
+      '7':
         'name': 'variable.parameter.table.legacy.sql'
-    'match': '^\\s*(?:(`)((?:[\\w\\-]+\\.)?(?:\\w+\\.)?\\w+)(\\*|\\$\\w+)?\\1|\\[((?:[\\w\\-]+\\:)?(?:\\w+\\.)?\\w+)(\\*|\\$\\w+)?\\])'
+    'match': '^\\s*(?:(`)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\1|\\[((?:[\\w\\-\\{\\}]+(?:\\:|(\\.)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\])'
     'name': 'meta.other.table.sql'
+  }
+  {
+    'captures':
+      '1':
+        'name': 'keyword.other.merge.sql'
+    'match': '(?i)(\\b(?:by)\\s+(?:target|source)\\b)'
+    'name': 'meta.create.DML.merge.sql'
   }
 
   {
@@ -157,6 +176,10 @@
   {
     'match': '(?i:\\b(create(\\s+(temporary|temp))?|drop|table|view|if|not|exists|partition|options|rows|range|unbounded|preceding|following|current|row|returns|language)\\b)'
     'name': 'keyword.other.DDL.sql'
+  }
+  {
+    'match': '(?i:\\b(merge|matched|default)\\b)'
+    'name': 'keyword.other.DML.merge.sql'
   }
   {
     'match': '(?i:\\b(over|ignore|respect|nulls|interval|at|zone|at\\s+time\\s+zone)\\b)'
@@ -432,6 +455,14 @@
       {
         'match': '(?i)\\b(COALESCE|IF|NULLIF|IFNULL)\\b'
         'name': 'support.function.conditional.sql'
+      }
+      {
+        'match': '(?i)\\b(ERROR)(?=\\s*\\()'
+        'name': 'support.function.debug.sql'
+      }
+      {
+        'match': '(?i)\\b(SAFE\\.\\w+)(?=\\s*\\()'
+        'name': 'support.function.debug.sql'
       }
 
       {

--- a/snippets/language-sql-bigquery.cson
+++ b/snippets/language-sql-bigquery.cson
@@ -98,6 +98,26 @@
       SET ${4:column} = ${5:value}
       WHERE ${6:condition}
     """
+  'UPDATE ... SET FROM':
+    'prefix': 'update from'
+    'body': """
+      UPDATE `${1:project}.${2:dataset}.${3:table}` a
+      SET ${4:column} = ${5:value}
+      FROM `${6:project}.${7:dataset}.${8:table}` b
+      WHERE a.${9:column} = b.${9:column}
+    """
+
+  'MERGE':
+    'prefix': 'merge'
+    'body': """
+      MERGE INTO `${1:project}.${2:dataset}.${3:target_table}` t
+      USING `${4:project}.${5:dataset}.${6:source_table}` s
+      ON ${7:merge_condition}
+      WHEN MATCHED THEN
+      \tUPDATE SET ${8:target_column} = ${9:value}
+      WHEN NOT MATCHED THEN
+      \tINSERT (${10:target_column, ...}) VALUES(${11:source_column, ...})
+    """
 
   'CREATE TABLE':
     'prefix': 'create table'
@@ -131,6 +151,40 @@
       \t${4:column} ${5:type}
       )
       PARTITION BY DATE(_PARTITIONTIME)
+    """
+  'CREATE TABLE AS SELECT':
+    'prefix': 'create table as select'
+    'body': """
+      CREATE TABLE `${1:project}.${2:dataset}.${3:table}`
+      (
+      \t${4:column} ${5:type}
+      ) AS
+      SELECT
+      \t${6:column}
+      FROM `${7:project}.${8:dataset}.${9:table}`
+      WHERE ${10:condition}
+    """
+  'CREATE TABLE OPTIONS':
+    'prefix': 'create table options'
+    'body': """
+      OPTIONS (
+      \tdescription = "description",
+      \texpiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+      \tpartition_expiration_days = 1,
+      \trequire_partition_filter = false,
+      \tlabels = [("key", "value")]
+      )
+    """
+  'OPTIONS':
+    'prefix': 'options'
+    'body': """
+      OPTIONS (
+      \tdescription = "description",
+      \texpiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+      \tpartition_expiration_days = 1,
+      \trequire_partition_filter = false,
+      \tlabels = [("key", "value")]
+      )
     """
 
   'CREATE VIEW':
@@ -1875,3 +1929,21 @@
   'EXTRACT(DAY FROM date_expression)':
     'prefix': 'day'
     'body': 'EXTRACT(DAY FROM ${1:date_expression})'
+
+  'ERROR()':
+    'prefix': 'error'
+    'body': 'ERROR(${1:error_message})'
+    'description': """
+      Returns an error. The error_message argument is a STRING.
+
+      BigQuery treats ERROR in the same way as any expression that may result in an error: there is no special guarantee of evaluation order.
+    """
+
+  'SAFE.prefix()':
+    'prefix': 'safeprefix'
+    'body': 'SAFE.${1:function_name()}'
+    'description': """
+      If you begin a function with the SAFE. prefix, it will return NULL instead of an error. The SAFE. prefix only prevents errors from the prefixed function itself: it does not prevent errors that occur while evaluating argument expressions. The SAFE. prefix only prevents errors that occur because of the value of the function inputs, such as "value out of range" errors; other errors, such as internal or system errors, may still occur. If the function does not return an error, SAFE. has no effect on the output. If the function never returns an error, like RAND, then SAFE. has no effect.
+
+      Operators, such as + and =, do not support the SAFE. prefix. To prevent errors from a division operation, use SAFE_DIVIDE. Some operators, such as IN, ARRAY, and UNNEST, resemble functions, but do not support the SAFE. prefix. The CAST and EXTRACT functions also do not support the SAFE. prefix. To prevent errors from casting, use SAFE_CAST.
+    """


### PR DESCRIPTION
### Requirements

- Add new syntax for after 2018 march.
- Miner fix

### Description of the Change

1. Add new function 'ERROR'

    - Function  
      `ERROR(error_message)`
    - Snippet  
      `error` -> `ERROR(error_message)`
    - Document  
      https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#error

1. Add new function 'SAFE.prefix'

    - Function  
      `SAFE.function_name()`
    - Snippet  
      `safeprefix` -> `SAFE.function_name()`
    - Document  
      https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#safe-prefix

1. Add snippet CTAS  
  BigQuery data definition language supports creating a table from the result of a query.

    - Snippet
        - Prefix  
          `create table as select`
        - body  
          ```sql
          CREATE TABLE `project.dataset.table`
          (
            column type
          ) AS
          SELECT
            column
          FROM `project.dataset.table`
          WHERE condition
          ```
    - Document  
      https://cloud.google.com/bigquery/docs/data-definition-language

1. Add snippet 'CREATE TABLE OPTIONS'

    - Snippet
        - Prefix
              - `create table options`
              - `options`
        - body
          ```sql
          OPTIONS (
            description = "description",
            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
            partition_expiration_days = 1,
            require_partition_filter = false,
            labels = [("key", "value")]
          )
          ```
    - Document  
      https://cloud.google.com/bigquery/docs/data-definition-language#options_clause

1. Add new statement 'MERGE'  
  BigQuery support for DML MERGE statements.

    - Syntax
      ```sql
      MERGE [INTO] target_name [[AS] alias]
      USING source_name
      ON merge_condition
      { when_clause }
      ```
    - Snippet
        - Prefix
          `merge`
        - body
          ```sql
          MERGE INTO target_name t
          USING source_name s
          ON merge_condition
          WHEN MATCHED THEN
            UPDATE SET target_column = value
          WHEN NOT MATCHED THEN
            INSERT (target_column, ...) VALUES(source_column, ...)
          ```
    - Document  
      https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax#merge_statement

1. Miner fix

### Applicable Issues

- #11 - Add new function 'ERROR'
- #12 - Add new function 'SAFE.prefix'
- #13 - Add snippet CTAS
- #14 - Add snippet 'CREATE TABLE OPTIONS'
- #15 - Add new statement 'MERGE'
