### PR TITLE
support NUMERIC type / add snippet of part EXTRACT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.2.3
+1. Add support 'NUMERIC' data type
+    - BigQuery added support for `NUMERIC` data type on May 15, 2018.
+
+2. Add snippet of part EXTRACT function
+    - Date EXTRACT
+        - `dayofweek` -> `EXTRACT(DAYOFWEEK FROM date_expression)`
+        - `dayofyear` -> `EXTRACT(DAYOFYEAR FROM date_expression)`
+        - `week` -> `EXTRACT(WEEK FROM date_expression)`
+        - `weekday` -> `EXTRACT(WEEK(<WEEKDAY>) FROM date_expression)`
+        - `isoweek` -> `EXTRACT(ISOWEEK FROM date_expression)`
+        - `quarter` -> `EXTRACT(QUARTER FROM date_expression)`
+        - `isoyear` -> `EXTRACT(ISOYEAR FROM date_expression)`
+
+    - Timestamp EXTRACT
+        - `microsecond` -> `EXTRACT(MICROSECOND FROM timestamp_expression [AT TIME ZONE tz_spec])`
+        - `millisecond` -> `EXTRACT(MILLISECOND FROM timestamp_expression [AT TIME ZONE tz_spec])`
+        - `second` -> `EXTRACT(SECOND FROM timestamp_expression [AT TIME ZONE tz_spec])`
+        - `minute` -> `EXTRACT(MINUTE FROM timestamp_expression [AT TIME ZONE tz_spec])`
+        - `hour` -> `EXTRACT(HOUR FROM timestamp_expression [AT TIME ZONE tz_spec])`
+
+3. Miner fix
+
 ## 0.2.2
 1. Add new function 'ERROR'
 

--- a/grammars/sql-bigquery.cson
+++ b/grammars/sql-bigquery.cson
@@ -108,7 +108,7 @@
   }
 
   {
-    'match': '(?i)\\b(array|boolean|bytes|date(?!\\s*\\()|datetime(?!\\s*\\()|float|float64|int64|integer|record|string(?!\\s*\\()|struct|time(?!\\s*\\(|\\s+as\\s+of|\\s+zone)|timestamp(?!\\s*\\())\\b'
+    'match': '(?i)\\b(array|boolean|bytes|date(?!\\s*\\()|datetime(?!\\s*\\()|numeric|float|float64|int64|integer|record|string(?!\\s*\\()|struct|time(?!\\s*\\(|\\s+as\\s+of|\\s+zone)|timestamp(?!\\s*\\())\\b'
     'name': 'storage.type.sql'
   }
   {

--- a/snippets/language-sql-bigquery.cson
+++ b/snippets/language-sql-bigquery.cson
@@ -51,9 +51,9 @@
     'body': """
       WITH ${1:with_query_name} AS (
         SELECT
-          ${1}
+          ${2}
         FROM
-          `${2:project}.${3:dataset}.${4:table}`
+          `${3:project}.${4:dataset}.${5:table}`
       )
 
     """
@@ -1920,15 +1920,52 @@
       Returns `NULL` if `expression = expression_to_match` is true, otherwise returns `expression`. `expression` and `expression_to_match` must be implicitly coercible to a common supertype; equality comparison is done on coerced values.
     """
 
-  'EXTRACT(YEAR FROM date_expression)':
-    'prefix': 'year'
-    'body': 'EXTRACT(YEAR FROM ${1:date_expression})'
-  'EXTRACT(MONTH FROM date_expression)':
-    'prefix': 'month'
-    'body': 'EXTRACT(MONTH FROM ${1:date_expression})'
+  'EXTRACT(DAYOFWEEK FROM date_expression)':
+    'prefix': 'dayofweek'
+    'body': 'EXTRACT(DAYOFWEEK FROM ${1:date_expression})'
   'EXTRACT(DAY FROM date_expression)':
     'prefix': 'day'
     'body': 'EXTRACT(DAY FROM ${1:date_expression})'
+  'EXTRACT(DAYOFYEAR FROM date_expression)':
+    'prefix': 'dayofyear'
+    'body': 'EXTRACT(DAYOFYEAR FROM ${1:date_expression})'
+  'EXTRACT(WEEK FROM date_expression)':
+    'prefix': 'week'
+    'body': 'EXTRACT(WEEK FROM ${1:date_expression})'
+  'EXTRACT(WEEK<WEEKDAY> FROM date_expression)':
+    'prefix': 'weekday'
+    'body': 'EXTRACT(WEEK(${1:<WEEKDAY>}) FROM ${2:date_expression})'
+  'EXTRACT(ISOWEEK FROM date_expression)':
+    'prefix': 'isoweek'
+    'body': 'EXTRACT(ISOWEEK FROM ${1:date_expression})'
+  'EXTRACT(MONTH FROM date_expression)':
+    'prefix': 'month'
+    'body': 'EXTRACT(MONTH FROM ${1:date_expression})'
+  'EXTRACT(QUARTER FROM date_expression)':
+    'prefix': 'quarter'
+    'body': 'EXTRACT(QUARTER FROM ${1:date_expression})'
+  'EXTRACT(YEAR FROM date_expression)':
+    'prefix': 'year'
+    'body': 'EXTRACT(YEAR FROM ${1:date_expression})'
+  'EXTRACT(ISOYEAR FROM date_expression)':
+    'prefix': 'isoyear'
+    'body': 'EXTRACT(ISOYEAR FROM ${1:date_expression})'
+
+  'EXTRACT(MICROSECOND FROM timestamp_expression)':
+    'prefix': 'microsecond'
+    'body': 'EXTRACT(MICROSECOND FROM ${1:timestamp_expression [AT TIME ZONE tz_spec]})'
+  'EXTRACT(MILLISECOND FROM timestamp_expression)':
+    'prefix': 'millisecond'
+    'body': 'EXTRACT(MILLISECOND FROM ${1:timestamp_expression [AT TIME ZONE tz_spec]})'
+  'EXTRACT(SECOND FROM timestamp_expression)':
+    'prefix': 'second'
+    'body': 'EXTRACT(SECOND FROM ${1:timestamp_expression [AT TIME ZONE tz_spec]})'
+  'EXTRACT(MINUTE FROM timestamp_expression)':
+    'prefix': 'minute'
+    'body': 'EXTRACT(MINUTE FROM ${1:timestamp_expression [AT TIME ZONE tz_spec]})'
+  'EXTRACT(HOUR FROM timestamp_expression)':
+    'prefix': 'hour'
+    'body': 'EXTRACT(HOUR FROM ${1:timestamp_expression [AT TIME ZONE tz_spec]})'
 
   'ERROR()':
     'prefix': 'error'


### PR DESCRIPTION
### Requirements

- Add support 'NUMERIC' data type
- Add snippet of part EXTRACT function
- Miner fix

### Description of the Change

1. Add support 'NUMERIC' data type
    - BigQuery added support for `NUMERIC` data type on May 15, 2018.

2. Add snippet of part EXTRACT function
    - Date EXTRACT
        - `dayofweek` -> `EXTRACT(DAYOFWEEK FROM date_expression)`
        - `dayofyear` -> `EXTRACT(DAYOFYEAR FROM date_expression)`
        - `week` -> `EXTRACT(WEEK FROM date_expression)`
        - `weekday` -> `EXTRACT(WEEK(<WEEKDAY>) FROM date_expression)`
        - `isoweek` -> `EXTRACT(ISOWEEK FROM date_expression)`
        - `quarter` -> `EXTRACT(QUARTER FROM date_expression)`
        - `isoyear` -> `EXTRACT(ISOYEAR FROM date_expression)`

    - Timestamp EXTRACT
        - `microsecond` -> `EXTRACT(MICROSECOND FROM timestamp_expression [AT TIME ZONE tz_spec])`
        - `millisecond` -> `EXTRACT(MILLISECOND FROM timestamp_expression [AT TIME ZONE tz_spec])`
        - `second` -> `EXTRACT(SECOND FROM timestamp_expression [AT TIME ZONE tz_spec])`
        - `minute` -> `EXTRACT(MINUTE FROM timestamp_expression [AT TIME ZONE tz_spec])`
        - `hour` -> `EXTRACT(HOUR FROM timestamp_expression [AT TIME ZONE tz_spec])`

3. Miner fix

### Applicable Issues

- #18 - Add support 'NUMERIC' data type
- #20 - Add snippet of part EXTRACT function
