### PR TITLE
add supports new function, clustered tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.2.4
+1. Add supports new function 'GENERATE_TIMESTAMP_ARRAY', 'FROM_BASE32' and 'TO_BASE32'
+    - GENERATE_TIMESTAMP_ARRAY
+        - Function  
+          `GENERATE_TIMESTAMP_ARRAY(start_timestamp, end_timestamp, INTERVAL step_expression date_part)`
+        - Snippet  
+          `generate_timestamp_array` -> `GENERATE_TIMESTAMP_ARRAY(start_timestamp, end_timestamp, INTERVAL step_expression date_part)`
+        - Document  
+          https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#generate_timestamp_array
+
+    - FROM_BASE32
+        - Function  
+          `FROM_BASE32(string_expr)`
+        - Snippet  
+          `from_base32` -> `FROM_BASE32(string_expr)`
+        - Document  
+          https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#from_base32
+
+    - TO_BASE32
+        - Function  
+          `TO_BASE32(bytes_expr)`
+        - Snippet  
+          `to_base32` -> `TO_BASE32(bytes_expr)`
+        - Document  
+          https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#to_base32
+
+2. Add supports 'clustered tables'
+    - Enhancement snippets
+        - `create table partition` (`CREATE TABLE ... PARTITION BY`)
+
+    - Add snippets
+        - `clusterby` -> `CLUSTER BY clustering_column_list`
+
+3. Miner fix
+
 ## 0.2.3
 1. Add support 'NUMERIC' data type
     - BigQuery added support for `NUMERIC` data type on May 15, 2018.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,15 @@
     - Add snippets
         - `clusterby` -> `CLUSTER BY clustering_column_list`
 
-3. Miner fix
+3. Add DDL options 'kms_key_name', 'friendly_name'
+    - Add snippets to DDL options
+      - `kms_key_name`
+      - `friendly_name`
+
+    - Document  
+      https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#table_option_list
+
+4. Miner fix
 
 ## 0.2.3
 1. Add support 'NUMERIC' data type

--- a/grammars/sql-bigquery.cson
+++ b/grammars/sql-bigquery.cson
@@ -174,7 +174,7 @@
     'name': 'keyword.other.DML.sql'
   }
   {
-    'match': '(?i:\\b(create(\\s+(temporary|temp))?|drop|table|view|if|not|exists|partition|options|rows|range|unbounded|preceding|following|current|row|returns|language)\\b)'
+    'match': '(?i:\\b(create(\\s+(temporary|temp))?|drop|table|view|if|not|exists|partition|cluster|options|rows|range|unbounded|preceding|following|current|row|returns|language)\\b)'
     'name': 'keyword.other.DDL.sql'
   }
   {
@@ -433,11 +433,11 @@
         'name': 'support.function.aggregate.sql'
       }
       {
-        'match': '(?i)\\b(ARRAY_(CONCAT|LENGTH|TO_STRING|REVERSE)|GENERATE_(ARRAY|DATE_ARRAY)|(SAFE_)?(OFFSET|ORDINAL))(?=\\s*\\()'
+        'match': '(?i)\\b(ARRAY_(CONCAT|LENGTH|TO_STRING|REVERSE)|GENERATE_(ARRAY|DATE_ARRAY|TIMESTAMP_ARRAY)|(SAFE_)?(OFFSET|ORDINAL))(?=\\s*\\()'
         'name': 'support.function.aggregate.sql.array'
       }
       {
-        'match': '(?i)\\b(BYTE_LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|CODE_POINTS_TO_(BYTES|STRING)|CONCAT|BYTE_LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|CONCAT|ENDS_WITH|FORMAT|FROM_(BASE64|HEX)|LENGTH|LPAD|LOWER|LTRIM|NORMALIZE|NORMALIZE_AND_CASEFOLD|REGEXP_(CONTAINS|EXTRACT|EXTRACT_ALL|REPLACE)|REPLACE(?!\\s+(table|view))|REPEAT|REVERSE|RPAD|RTRIM|SAFE_CONVERT_BYTES_TO_STRING|SPLIT|STARTS_WITH|STRPOS|SUBSTR|TO_(BASE64|CODE_POINTS|HEX)|TRIM|UPPER)\\b'
+        'match': '(?i)\\b(BYTE_LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|CODE_POINTS_TO_(BYTES|STRING)|CONCAT|BYTE_LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|CONCAT|ENDS_WITH|FORMAT|FROM_(BASE32|BASE64|HEX)|LENGTH|LPAD|LOWER|LTRIM|NORMALIZE|NORMALIZE_AND_CASEFOLD|REGEXP_(CONTAINS|EXTRACT|EXTRACT_ALL|REPLACE)|REPLACE(?!\\s+(table|view))|REPEAT|REVERSE|RPAD|RTRIM|SAFE_CONVERT_BYTES_TO_STRING|SPLIT|STARTS_WITH|STRPOS|SUBSTR|TO_(BASE32|BASE64|CODE_POINTS|HEX)|TRIM|UPPER)\\b'
         'name': 'support.function.string.sql'
       }
       {

--- a/snippets/language-sql-bigquery.cson
+++ b/snippets/language-sql-bigquery.cson
@@ -46,6 +46,12 @@
   'ORDER BY':
     'prefix': 'orderby'
     'body': 'ORDER BY ${1}'
+  'PARTITION BY':
+    'prefix': 'partitionby'
+    'body': 'PARTITION BY ${1:DATE(_PARTITIONTIME)|DATE(<timestamp_column>)|<date_column>}'
+  'CLUSTER BY':
+    'prefix': 'clusterby'
+    'body': 'CLUSTER BY ${1:clustering_column_list}'
   'WITH ... AS':
     'prefix': 'with'
     'body': """
@@ -150,7 +156,8 @@
       (
       \t${4:column} ${5:type}
       )
-      PARTITION BY DATE(_PARTITIONTIME)
+      PARTITION BY ${6:DATE(_PARTITIONTIME)|DATE(<timestamp_column>)|<date_column>}
+      ${7:[CLUSTER BY clustering_column_list]}
     """
   'CREATE TABLE AS SELECT':
     'prefix': 'create table as select'
@@ -172,6 +179,8 @@
       \texpiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
       \tpartition_expiration_days = 1,
       \trequire_partition_filter = false,
+      \tkms_key_name = "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]",
+      \tfriendly_name = "friendly_name",
       \tlabels = [("key", "value")]
       )
     """
@@ -183,6 +192,8 @@
       \texpiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
       \tpartition_expiration_days = 1,
       \trequire_partition_filter = false,
+      \tkms_key_name = "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]",
+      \tfriendly_name = "friendly_name",
       \tlabels = [("key", "value")]
       )
     """
@@ -886,6 +897,12 @@
     'description': """
       BigQuery supports a FORMAT() function for formatting strings. This function is similar to the C printf function. It produces a STRING from a format string that contains zero or more format specifiers, along with a variable length list of additional arguments that matches the format specifiers.
     """
+  'FROM_BASE32()':
+    'prefix': 'from_base32'
+    'body': 'FROM_BASE32(${1:string_expr})'
+    'description': """
+      Converts the base32-encoded input `string_expr` into BYTES format. To convert BYTES to a base32-encoded STRING, use TO_BASE32.
+    """
   'FROM_BASE64()':
     'prefix': 'from_base64'
     'body': 'FROM_BASE64(${1:string_expr})'
@@ -1050,6 +1067,12 @@
 
       If `position` is negative, the function counts from the end of `value`, with -1 indicating the last character.
     """
+  'TO_BASE32()':
+    'prefix': 'to_base32'
+    'body': 'TO_BASE32(${1:bytes_expr})'
+    'description': """
+      Converts a sequence of BYTES into a base32-encoded STRING. To convert a base32-encoded STRING into BYTES, use FROM_BASE32.
+    """
   'TO_BASE64()':
     'prefix': 'to_base64'
     'body': 'TO_BASE64(${1:bytes_expr})'
@@ -1159,6 +1182,21 @@
       The `INT64_expr` parameter determines the increment used to generate dates. The default value for this parameter is 1 day.
 
       This function returns an error if `INT64_expr` is set to 0.
+    """
+  'GENERATE_TIMESTAMP_ARRAY()':
+    'prefix': 'generate_timestamp_array'
+    'body': 'GENERATE_TIMESTAMP_ARRAY(${1:start_timestamp}, ${2:end_timestamp[, INTERVAL step_expression date_part]})'
+    'description': """
+      Returns an `ARRAY` of `TIMESTAMPS` separated by a given interval. The `start_timestamp` and `end_timestamp` parameters determine the inclusive lower and upper bounds of the `ARRAY`.
+
+      The GENERATE_TIMESTAMP_ARRAY function accepts the following data types as inputs:
+
+        * `start_timestamp`: TIMESTAMP
+        * `end_timestamp`: TIMESTAMP
+        * `step_expression`: INT64
+        * Allowed date_part values are MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, or DAY.
+
+      The step_expression parameter determines the increment used to generate timestamps.
     """
   '[OFFSET(zero_based_offset)]':
     'prefix': 'offset'


### PR DESCRIPTION
### Requirements

- Add supports new function 'GENERATE_TIMESTAMP_ARRAY', 'FROM_BASE32' and 'TO_BASE32'
- Add supports 'clustered tables'
- Miner fix

### Description of the Change

1. Add supports new function 'GENERATE_TIMESTAMP_ARRAY', 'FROM_BASE32' and 'TO_BASE32'
    - GENERATE_TIMESTAMP_ARRAY
        - Function  
          `GENERATE_TIMESTAMP_ARRAY(start_timestamp, end_timestamp, INTERVAL step_expression date_part)`
        - Snippet  
          `generate_timestamp_array` -> `GENERATE_TIMESTAMP_ARRAY(start_timestamp, end_timestamp, INTERVAL step_expression date_part)`
        - Document  
          https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#generate_timestamp_array

    - FROM_BASE32
        - Function  
          `FROM_BASE32(string_expr)`
        - Snippet  
          `from_base32` -> `FROM_BASE32(string_expr)`
        - Document  
          https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#from_base32

    - TO_BASE32
        - Function  
          `TO_BASE32(bytes_expr)`
        - Snippet  
          `to_base32` -> `TO_BASE32(bytes_expr)`
        - Document  
          https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#to_base32

3. Add DDL options 'kms_key_name', 'friendly_name'
    - Add snippets to DDL options
      - `kms_key_name`
      - `friendly_name`

    - Document  
      https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#table_option_list

4. Miner fix

### Applicable Issues

- fix #22 - Add supports new function 'GENERATE_TIMESTAMP_ARRAY', 'FROM_BASE32' and 'TO_BASE32'
- fix #24 - Add supports 'clustered tables'
- fix #26 - Add DDL options 'kms_key_name', 'friendly_name'
