### PR TITLE
add support UDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.2.5
+1. Added supports UDF(User-Defined Functions)
+    - Supported 'JavaScript UDF' highlighting
+    - Added snippets of UDF
+        - JavaScript UDF
+            - Prefix  
+              `create function javascript`
+            - body
+              ```sql
+              CREATE TEMPORARY FUNCTION functionName(param_name param_type[, ...])
+              RETURNS data_type
+              LANGUAGE js AS """
+                return "expression";
+              """;
+              ```
+        - SQL UDF
+            - Prefix  
+              `create function sql`
+            - body
+              ```sql
+              CREATE TEMPORARY FUNCTION functionName(param_name param_type[, ...])
+              [RETURNS data_type]
+              AS (
+                sql_expression
+              );
+              ```
+    - Document  
+      https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions
+
 ## 0.2.4
 1. Add supports new function 'GENERATE_TIMESTAMP_ARRAY', 'FROM_BASE32' and 'TO_BASE32'
     - GENERATE_TIMESTAMP_ARRAY
@@ -135,7 +164,7 @@
       { when_clause }
       ```
     - Snippet
-        - Prefix
+        - Prefix  
           `merge`
         - body
           ```sql

--- a/grammars/sql-bigquery.cson
+++ b/grammars/sql-bigquery.cson
@@ -25,6 +25,9 @@
     'include': '#regexps'
   }
   {
+    'include': '#javascript'
+  }
+  {
     'captures':
       '1':
         'name': 'keyword.other.create.sql'
@@ -296,6 +299,31 @@
         'patterns': [
           {
             'include': '#string_interpolation'
+          }
+        ]
+      }
+    ]
+
+  'javascript':
+    'patterns': [
+      {
+        'begin': '(?i:\\b(language)\\s+(js)\\s+(as)\\s+)(""")'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.other.alias.sql'
+          '3':
+            'name': 'keyword.other.alias.sql'
+          '4':
+            'name': 'string.quoted.double.begin.sql'
+        'end': '"""'
+        'endCaptures':
+          '0':
+            'name': 'string.quoted.double.end.sql'
+        'name': 'meta.embedded.js'
+        'contentName': 'source.embedded.js'
+        'patterns': [
+          {
+            'include': 'source.js'
           }
         ]
       }

--- a/snippets/language-sql-bigquery.cson
+++ b/snippets/language-sql-bigquery.cson
@@ -223,6 +223,25 @@
       FROM `${5:project}.${5:dataset}.${6:table}`
     """
 
+  'CREATE JavaScript FUNCTION':
+    'prefix': 'create function javascript'
+    'body': """
+      CREATE TEMPORARY FUNCTION ${1:functionName}(${2:param_name param_type[, ...]})
+      RETURNS ${3:data_type}
+      LANGUAGE js AS \"\"\"
+      \t${4:return \"expression\";}
+      \"\"\";
+    """
+  'CREATE SQL FUNCTION':
+    'prefix': 'create function sql'
+    'body': """
+      CREATE TEMPORARY FUNCTION ${1:functionName}(${2:param_name param_type[, ...]})
+      ${3:[RETURNS data_type]}
+      AS (
+      \t${4:sql_expression}
+      );
+    """
+
   'DROP TABLE':
     'prefix': 'drop table'
     'body': """


### PR DESCRIPTION
### Requirements

- Added supports UDF(User-Defined Functions)
    - Supported 'JavaScript UDF' highlighting
    - Added snippets of UDF

### Description of the Change

1. Added supports UDF(User-Defined Functions)
    - Supported 'JavaScript UDF' highlighting
    - Added snippets of UDF
        - JavaScript UDF
            - Prefix  
              `create function javascript`
            - body
              ```sql
              CREATE TEMPORARY FUNCTION functionName(param_name param_type[, ...])
              RETURNS data_type
              LANGUAGE js AS """
                return "expression";
              """;
              ```
        - SQL UDF
            - Prefix  
              `create function sql`
            - body
              ```sql
              CREATE TEMPORARY FUNCTION functionName(param_name param_type[, ...])
              [RETURNS data_type]
              AS (
                sql_expression
              );
              ```
    - Document  
      https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions

### Applicable Issues

- fix #23 - Support 'JavaScript UDF' highlighting
- fix #28 - Add snippet of UDF
