### PR TITLE
add support 'BOOL' data type, 'BigQuery ML'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.2.6
+1. Add support 'BOOL' data type
+    - Supported syntax highlighting
+2. Added supports 'BigQuery ML'
+    - Supported syntax highlighting
+    - Added snippets of `CREATE MODEL` statement
+        - Prefix  
+          `create model`
+        - body
+          ```sql
+          CREATE MODEL | CREATE MODEL IF NOT EXISTS | CREATE OR REPLACE MODEL `project.dataset.model`
+          [OPTIONS(model_option_list)]
+          [AS query_statement]
+          ```
+    - Added snippets of `ML.EVALUATE` function
+        - Prefix  
+          `mlevaluate`
+        - body
+          ```sql
+          ML.EVALUATE(MODEL `project.dataset.model`,
+            {TABLE table_name | (query_statement)},
+            [STRUCT( AS threshold)])
+          ```
+    - Added snippets of `ML.ROC_CURVE` function
+        - Prefix  
+          `mlroccurve`
+        - body
+          ```sql
+          ML.ROC_CURVE(MODEL `project.dataset.model`,
+            {TABLE table_name | (query_statement)},
+            [GENERATE_ARRAY(thresholds)])
+          ```
+
 ## 0.2.5
 1. Added supports UDF(User-Defined Functions)
     - Supported 'JavaScript UDF' highlighting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.2.6
 1. Add support 'BOOL' data type
     - Supported syntax highlighting
+    - Document  
+      https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#boolean-type
 2. Added supports 'BigQuery ML'
     - Supported syntax highlighting
     - Added snippets of `CREATE MODEL` statement
@@ -32,6 +34,8 @@
             {TABLE table_name | (query_statement)},
             [GENERATE_ARRAY(thresholds)])
           ```
+    - Document  
+      https://cloud.google.com/bigquery/docs/bigqueryml
 
 ## 0.2.5
 1. Added supports UDF(User-Defined Functions)

--- a/grammars/sql-bigquery.cson
+++ b/grammars/sql-bigquery.cson
@@ -39,7 +39,7 @@
         'name': 'entity.name.function.sql'
       '6':
         'name': 'invalid.illegal.table.delimiter.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?|drop)\\s+(table|view)\\b(?:\\s+(if(?:\\s+not)?\\s+exists)\\b)?)(?:\\s+(`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}\\*]+)\\4)?'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?|drop)\\s+(table|view|model)\\b(?:\\s+(if(?:\\s+not)?\\s+exists)\\b)?)(?:\\s+(`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}\\*]+)\\4)?'
     'name': 'meta.create.sql'
   }
   {
@@ -87,6 +87,19 @@
   }
   {
     'captures':
+      '1':
+        'name': 'keyword.other.insert.sql'
+      '3':
+        'name': 'entity.name.function.table.standard.sql'
+      '4':
+        'name': 'invalid.illegal.table.delimiter.sql'
+      '5':
+        'name': 'variable.parameter.table.partition_decorator.sql'
+    'match': '(?i:\\b(model)\\s+(?:(`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\2)?)'
+    'name': 'meta.other.table.ml.sql'
+  }
+  {
+    'captures':
       '2':
         'name': 'entity.name.function.table.standard.sql'
       '3':
@@ -111,7 +124,7 @@
   }
 
   {
-    'match': '(?i)\\b(array|boolean|bytes|date(?!\\s*\\()|datetime(?!\\s*\\()|numeric|float|float64|int64|integer|record|string(?!\\s*\\()|struct|time(?!\\s*\\(|\\s+as\\s+of|\\s+zone)|timestamp(?!\\s*\\())\\b'
+    'match': '(?i)\\b(array|boolean|bytes|date(?!\\s*\\()|datetime(?!\\s*\\()|numeric|float|float64|int64|integer|bool|record|string(?!\\s*\\()|struct|time(?!\\s*\\(|\\s+as\\s+of|\\s+zone)|timestamp(?!\\s*\\())\\b'
     'name': 'storage.type.sql'
   }
   {
@@ -177,7 +190,7 @@
     'name': 'keyword.other.DML.sql'
   }
   {
-    'match': '(?i:\\b(create(\\s+(temporary|temp))?|drop|table|view|if|not|exists|partition|cluster|options|rows|range|unbounded|preceding|following|current|row|returns|language)\\b)'
+    'match': '(?i:\\b(create(\\s+(temporary|temp))?|drop|table|view|model|if|not|exists|partition|cluster|options|rows|range|unbounded|preceding|following|current|row|returns|language)\\b)'
     'name': 'keyword.other.DDL.sql'
   }
   {
@@ -465,7 +478,7 @@
         'name': 'support.function.aggregate.sql.array'
       }
       {
-        'match': '(?i)\\b(BYTE_LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|CODE_POINTS_TO_(BYTES|STRING)|CONCAT|BYTE_LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|CONCAT|ENDS_WITH|FORMAT|FROM_(BASE32|BASE64|HEX)|LENGTH|LPAD|LOWER|LTRIM|NORMALIZE|NORMALIZE_AND_CASEFOLD|REGEXP_(CONTAINS|EXTRACT|EXTRACT_ALL|REPLACE)|REPLACE(?!\\s+(table|view))|REPEAT|REVERSE|RPAD|RTRIM|SAFE_CONVERT_BYTES_TO_STRING|SPLIT|STARTS_WITH|STRPOS|SUBSTR|TO_(BASE32|BASE64|CODE_POINTS|HEX)|TRIM|UPPER)\\b'
+        'match': '(?i)\\b(BYTE_LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|CODE_POINTS_TO_(BYTES|STRING)|CONCAT|BYTE_LENGTH|CHAR_LENGTH|CHARACTER_LENGTH|CONCAT|ENDS_WITH|FORMAT|FROM_(BASE32|BASE64|HEX)|LENGTH|LPAD|LOWER|LTRIM|NORMALIZE|NORMALIZE_AND_CASEFOLD|REGEXP_(CONTAINS|EXTRACT|EXTRACT_ALL|REPLACE)|REPLACE(?!\\s+(table|view|model))|REPEAT|REVERSE|RPAD|RTRIM|SAFE_CONVERT_BYTES_TO_STRING|SPLIT|STARTS_WITH|STRPOS|SUBSTR|TO_(BASE32|BASE64|CODE_POINTS|HEX)|TRIM|UPPER)\\b'
         'name': 'support.function.string.sql'
       }
       {
@@ -491,6 +504,10 @@
       {
         'match': '(?i)\\b(SAFE\\.\\w+)(?=\\s*\\()'
         'name': 'support.function.debug.sql'
+      }
+      {
+        'match': '(?i)\\b(ML\\.(EVALUATE|ROC_CURVE))\\b'
+        'name': 'support.function.ml.sql'
       }
 
       {

--- a/snippets/language-sql-bigquery.cson
+++ b/snippets/language-sql-bigquery.cson
@@ -242,6 +242,15 @@
       );
     """
 
+  'CREATE MODEL':
+    'prefix': 'create model'
+    'body': """
+      ${1:CREATE MODEL | CREATE MODEL IF NOT EXISTS | CREATE OR REPLACE MODEL} `${2:project}.${3:dataset}.${4:model}`
+      ${5:[OPTIONS(model_option_list)]}
+      AS
+      ${6:query_statement}
+    """
+
   'DROP TABLE':
     'prefix': 'drop table'
     'body': """
@@ -2040,4 +2049,19 @@
       If you begin a function with the SAFE. prefix, it will return NULL instead of an error. The SAFE. prefix only prevents errors from the prefixed function itself: it does not prevent errors that occur while evaluating argument expressions. The SAFE. prefix only prevents errors that occur because of the value of the function inputs, such as "value out of range" errors; other errors, such as internal or system errors, may still occur. If the function does not return an error, SAFE. has no effect on the output. If the function never returns an error, like RAND, then SAFE. has no effect.
 
       Operators, such as + and =, do not support the SAFE. prefix. To prevent errors from a division operation, use SAFE_DIVIDE. Some operators, such as IN, ARRAY, and UNNEST, resemble functions, but do not support the SAFE. prefix. The CAST and EXTRACT functions also do not support the SAFE. prefix. To prevent errors from casting, use SAFE_CAST.
+    """
+
+  'ML.EVALUATE()':
+    'prefix': 'mlevaluate'
+    'body': """
+      ML.EVALUATE(MODEL `${1:project}.${2:dataset}.${3:model}`,
+      \t${4:\{TABLE table_name | (query_statement)\}},
+      \t${5:[STRUCT( AS threshold)]})
+    """
+  'ML.ROC_CURVE()':
+    'prefix': 'mlroccurve'
+    'body': """
+      ML.ROC_CURVE(MODEL `${1:project}.${2:dataset}.${3:model}`,
+      \t${4:\{TABLE table_name | (query_statement)\}},
+      \t${5:[GENERATE_ARRAY(thresholds)]})
     """


### PR DESCRIPTION
### Requirements

1. Add supports 'BOOL' data type
2. Added supports 'BigQuery ML'

### Description of the Change

1. Add supports 'BOOL' data type
    - Supported syntax highlighting
    - Document  
      https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#boolean-type
2. Added supports 'BigQuery ML'
    - Supported syntax highlighting
    - Added snippets of `CREATE MODEL` statement
        - Prefix  
          `create model`
        - body
          ```sql
          CREATE MODEL | CREATE MODEL IF NOT EXISTS | CREATE OR REPLACE MODEL `project.dataset.model`
          [OPTIONS(model_option_list)]
          [AS query_statement]
          ```
    - Added snippets of `ML.EVALUATE` function
        - Prefix  
          `mlevaluate`
        - body
          ```sql
          ML.EVALUATE(MODEL `project.dataset.model`,
            {TABLE table_name | (query_statement)},
            [STRUCT( AS threshold)])
          ```
    - Added snippets of `ML.ROC_CURVE` function
        - Prefix  
          `mlroccurve`
        - body
          ```sql
          ML.ROC_CURVE(MODEL `project.dataset.model`,
            {TABLE table_name | (query_statement)},
            [GENERATE_ARRAY(thresholds)])
          ```
    - Document  
      https://cloud.google.com/bigquery/docs/bigqueryml

### Applicable Issues

- fix #25 - Add supports 'BigQuery ML'
- fix #30 - Add support 'BOOL' data type
