### PR TITLE
Add supports 'BigQuery ML' functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,38 @@
 # Changelog
 
+## 0.2.7
+1. Added supports 'BigQuery ML' functions
+    - Supported syntax highlighting
+    - Added snippets of `ML.TRAINING_INFO` function
+        - Prefix  
+          `mltraininginfo`
+        - body
+          ```sql
+          ML.TRAINING_INFO(MODEL `project.dataset.model`)
+          ```
+        - Document  
+          https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-train
+    - Added snippets of `ML.FEATURE_INFO` function
+        - Prefix  
+          `mlfeatureinfo`
+        - body
+          ```sql
+          ML.FEATURE_INFO(MODEL `project.dataset.model`)
+          ```
+        - Document  
+          https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-feature
+    - Added snippets of `ML.WEIGHTS` function
+        - Prefix  
+          `mlweights`
+        - body
+          ```sql
+          ML.WEIGHTS(MODEL `project.dataset.model`)
+          ```
+        - Document  
+          https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-weights
+
 ## 0.2.6
-1. Add support 'BOOL' data type
+1. Added supports 'BOOL' data type
     - Supported syntax highlighting
     - Document  
       https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#boolean-type

--- a/grammars/sql-bigquery.cson
+++ b/grammars/sql-bigquery.cson
@@ -506,7 +506,7 @@
         'name': 'support.function.debug.sql'
       }
       {
-        'match': '(?i)\\b(ML\\.(EVALUATE|ROC_CURVE))\\b'
+        'match': '(?i)\\b(ML\\.(EVALUATE|ROC_CURVE|TRAINING_INFO|FEATURE_INFO|WEIGHTS))\\b'
         'name': 'support.function.ml.sql'
       }
 

--- a/snippets/language-sql-bigquery.cson
+++ b/snippets/language-sql-bigquery.cson
@@ -2065,3 +2065,12 @@
       \t${4:\{TABLE table_name | (query_statement)\}},
       \t${5:[GENERATE_ARRAY(thresholds)]})
     """
+  'ML.TRAINING_INFO()':
+    'prefix': 'mltraininginfo'
+    'body': 'ML.TRAINING_INFO(MODEL `${1:project}.${2:dataset}.${3:model}`)'
+  'ML.FEATURE_INFO()':
+    'prefix': 'mlfeatureinfo'
+    'body': 'ML.FEATURE_INFO(MODEL `${1:project}.${2:dataset}.${3:model}`)'
+  'ML.WEIGHTS()':
+    'prefix': 'mlweights'
+    'body': 'ML.WEIGHTS(MODEL `${1:project}.${2:dataset}.${3:model}`)'


### PR DESCRIPTION
### Requirements

1. Added supports 'BigQuery ML' functions
    - Added function
        - `ML.TRAINING_INFO`
        - `ML.FEATURE_INFO`
        - `ML.WEIGHTS`
    - Supports syntax highlighting
    - Added snippets

### Description of the Change

1. Added supports 'BigQuery ML' functions
    - Supports syntax highlighting
    - Add snippets of `ML.TRAINING_INFO` function
        - Prefix  
          `mltraininginfo`
        - body
          ```sql
          ML.TRAINING_INFO(MODEL `project.dataset.model`)
          ```
        - Document  
          https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-train
    - Add snippets of `ML.FEATURE_INFO` function
        - Prefix  
          `mlfeatureinfo`
        - body
          ```sql
          ML.FEATURE_INFO(MODEL `project.dataset.model`)
          ```
        - Document  
          https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-feature
    - Add snippets of `ML.WEIGHTS` function
        - Prefix  
          `mlweights`
        - body
          ```sql
          ML.WEIGHTS(MODEL `project.dataset.model`)
          ```
        - Document  
          https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-weights

### Applicable Issues

- fix #32 - Add supports 'BigQuery ML' functions
