### PR TITLE
add supports 'ML.PREDICT' function, enhancement 'ML.PREDICT' function snippets, fix syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,47 @@
 # Changelog
 
+## 1.0.0
+1. Added supports new function `ML.PREDICT`
+  - Supported syntax highlighting
+  - Added snippets of `ML.PREDICT` function
+      - Prefix  
+        `mlpredict`
+      - body
+        ```sql
+        ML.PREDICT(MODEL `project.dataset.model`,
+          {TABLE table_name | (query_statement)},
+          [STRUCT(<threshold FLOAT64> AS threshold)])
+        ```
+      - Document  
+        https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-predict
+  - BigQuery release notes
+    - [December 13, 2018](https://cloud.google.com/bigquery/docs/release-notes#december_13_2018)
+
+2. Added supports `ML.PREDICT` function standardization parameter
+  - Snippet supports to addition of standardization parameter.
+    - Prefix  
+      `mlpredict`
+    - body
+      - old
+        ```sql
+        ML.WEIGHTS(MODEL `project.dataset.model`)
+        ```
+      - new
+        ```sql
+        ML.WEIGHTS(MODEL `project.dataset.model`,
+          [STRUCT(<T> AS standardize)])
+        ```
+    - Document  
+      https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-weights
+  - BigQuery release notes
+    - [December 13, 2018](https://cloud.google.com/bigquery/docs/release-notes#december_13_2018)
+
+3. Fix syntax highlighting of strings
+
+
 ## 0.2.8
 1. Added supports 'BigQuery ML' functions
     - Supported syntax highlighting
-    - Added snippets
-    - Functions
     - Added snippets of `ML.CONFUSION_MATRIX` function
         - Prefix  
           `mlconfusionmatrix`

--- a/grammars/sql-bigquery.cson
+++ b/grammars/sql-bigquery.cson
@@ -299,11 +299,11 @@
   'regexps':
     'patterns': [
       {
-        'begin': 'r[\'"]'
+        'begin': 'r[\'\"]'
         'beginCaptures':
           '0':
             'name': 'storage.type.string.regex.begin.sql'
-        'end': '[\'"]'
+        'end': '[\'\"]'
         'endCaptures':
           '0':
             'name': 'storage.type.string.regex.end.sql'
@@ -312,6 +312,7 @@
         'patterns': [
           {
             'include': '#string_interpolation'
+            'include': '#string_escape'
           }
         ]
       }
@@ -382,6 +383,22 @@
         ]
       }
       {
+        'begin': '\"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '\"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.quoted.double.sql'
+        'patterns': [
+          {
+            'include': '#string_escape'
+          }
+        ]
+      }
+      {
         'captures':
           '1':
             'name': 'punctuation.definition.string.begin.sql'
@@ -416,22 +433,6 @@
         'comment': 'this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.'
         'match': '(")[^"#]*(")'
         'name': 'string.quoted.double.sql'
-      }
-      {
-        'begin': '"'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.sql'
-        'end': '"'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.sql'
-        'name': 'string.quoted.double.sql'
-        'patterns': [
-          {
-            'include': '#string_interpolation'
-          }
-        ]
       }
       {
         'begin': '%\\{'
@@ -506,7 +507,7 @@
         'name': 'support.function.debug.sql'
       }
       {
-        'match': '(?i)\\b(ML\\.(EVALUATE|ROC_CURVE|CONFUSION_MATRIX|TRAINING_INFO|FEATURE_INFO|WEIGHTS))\\b'
+        'match': '(?i)\\b(ML\\.(EVALUATE|ROC_CURVE|CONFUSION_MATRIX|TRAINING_INFO|FEATURE_INFO|WEIGHTS|PREDICT))\\b'
         'name': 'support.function.ml.sql'
       }
       {

--- a/snippets/language-sql-bigquery.cson
+++ b/snippets/language-sql-bigquery.cson
@@ -2056,7 +2056,7 @@
     'body': """
       ML.EVALUATE(MODEL `${1:project}.${2:dataset}.${3:model}`,
       \t${4:\{TABLE table_name | (query_statement)\}},
-      \t${5:[STRUCT( AS threshold)]})
+      \t${5:[STRUCT(<T> AS threshold)]})
     """
   'ML.ROC_CURVE()':
     'prefix': 'mlroccurve'
@@ -2080,7 +2080,17 @@
     'body': 'ML.FEATURE_INFO(MODEL `${1:project}.${2:dataset}.${3:model}`)'
   'ML.WEIGHTS()':
     'prefix': 'mlweights'
-    'body': 'ML.WEIGHTS(MODEL `${1:project}.${2:dataset}.${3:model}`)'
+    'body': """
+      ML.WEIGHTS(MODEL `${1:project}.${2:dataset}.${3:model}`,
+      \t${4:[STRUCT(<T> AS standardize)]})
+    """
+  'ML.PREDICT()':
+    'prefix': 'mlpredict'
+    'body': """
+      ML.PREDICT(MODEL `${1:project}.${2:dataset}.${3:model}`,
+      \t${4:\{TABLE table_name | (query_statement)\}},
+      \t${5:[STRUCT(<threshold FLOAT64> AS threshold)]})
+    """
 
   'ST_GEOGPOINT()':
     'prefix': 'stgeogpoint'


### PR DESCRIPTION
### Requirements

- Add supports new function 'ML.PREDICT'
- Add supports `ML.PREDICT` function standardization parameter
- Fix syntax highlighting of strings

### Description of the Change

1. Added supports new function `ML.PREDICT`
    - Supported syntax highlighting
    - Added snippets of `ML.PREDICT` function
        - Prefix  
          `mlpredict`
        - body
          ```sql
          ML.PREDICT(MODEL `project.dataset.model`,
              {TABLE table_name | (query_statement)},
              [STRUCT(<threshold FLOAT64> AS threshold)])
          ```
        - Document  
          https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-predict
    - BigQuery release notes
        - [December 13, 2018](https://cloud.google.com/bigquery/docs/release-notes#december_13_2018)

2. Added supports `ML.PREDICT` function standardization parameter
    - Snippet supports to addition of standardization parameter.
        - Prefix  
          `mlpredict`
        - body
            - old
              ```sql
              ML.WEIGHTS(MODEL `project.dataset.model`)
              ```
            - new
              ```sql
              ML.WEIGHTS(MODEL `project.dataset.model`,
                  [STRUCT(<T> AS standardize)])
              ```
        - Document  
          https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-weights
    - BigQuery release notes
        - [December 13, 2018](https://cloud.google.com/bigquery/docs/release-notes#december_13_2018)

3. Fix syntax highlighting of strings

### Applicable Issues

- fix #38 - Add supports new function 'ML.PREDICT'
- fix #39 - 'ML.PREDICT' function supports standardization parameter
- fix #37 - Problem with syntax highlighting after escaped quote characters
