### PR TITLE
add supports alter DDL, INFORMATION_SCHEMA views, _TABLE_SUFFIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.1.0
-1. Added snippet `_TABLE_SUFFIX`
+1. Added supports `_TABLE_SUFFIX`
     - Snippet
         - Prefix
             - `_table_suffix`
@@ -13,7 +13,7 @@
     - Document  
       https://cloud.google.com/bigquery/docs/querying-wildcard-tables
 
-2. Added snippet `ALTER TABLE SET OPTIONS` statement
+2. Added supports `ALTER TABLE SET OPTIONS` statement
     - Snippet - `ALTER TABLE SET OPTIONS`
         - Prefix  
           `altertable`
@@ -49,7 +49,7 @@
     - Document  
       https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_set_options_statement
 
-3. Added snippet `ALTER VIEW SET OPTIONS` statement
+3. Added supports `ALTER VIEW SET OPTIONS` statement
     - Snippet - `ALTER VIEW SET OPTIONS`
         - Prefix  
           `alterview`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,220 @@
 # Changelog
 
+## 1.1.0
+1. Added snippet `_TABLE_SUFFIX`
+    - Snippet
+        - Prefix
+            - `_table_suffix`
+            - `table_suffix`
+        - Body
+          ```sql
+          _TABLE_SUFFIX BETWEEN "${1:from}" AND "${2:to}"
+          ```
+    - Document  
+      https://cloud.google.com/bigquery/docs/querying-wildcard-tables
+
+2. Added snippet `ALTER TABLE SET OPTIONS` statement
+    - Snippet - `ALTER TABLE SET OPTIONS`
+        - Prefix  
+          `altertable`
+        - Body
+          ```sql
+          ALTER TABLE `${1:project}.${2:dataset}.${3:table}`
+          SET OPTIONS (
+            description = "description",
+            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+            partition_expiration_days = 1,
+            require_partition_filter = false,
+            kms_key_name = "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]",
+            friendly_name = "friendly_name",
+            labels = [("key", "value")]
+          )
+          ```
+    - Snippet - `ALTER TABLE IF EXISTS SET OPTIONS`
+        - Prefix  
+          `altertableifexists`
+        - Body
+          ```sql
+          ALTER TABLE IF EXISTS `${1:project}.${2:dataset}.${3:table}`
+          SET OPTIONS (
+            description = "description",
+            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+            partition_expiration_days = 1,
+            require_partition_filter = false,
+            kms_key_name = "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]",
+            friendly_name = "friendly_name",
+            labels = [("key", "value")]
+          )
+          ```
+    - Document  
+      https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_set_options_statement
+
+3. Added snippet `ALTER VIEW SET OPTIONS` statement
+    - Snippet - `ALTER VIEW SET OPTIONS`
+        - Prefix  
+          `alterview`
+        - Body
+          ```sql
+          ALTER VIEW `${1:project}.${2:dataset}.${3:view}`
+          SET OPTIONS (
+            description = "description",
+            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+            friendly_name = "friendly_name",
+            labels = [("key", "value")]
+          )
+          ```
+    - Snippet - `ALTER VIEW IF EXISTS SET OPTIONS`
+        - Prefix  
+          `alterviewifexists`
+        - Body
+          ```sql
+          ALTER VIEW IF EXISTS `${1:project}.${2:dataset}.${3:view}`
+          SET OPTIONS (
+            description = "description",
+            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+            friendly_name = "friendly_name",
+            labels = [("key", "value")]
+          )
+          ```
+    - Document  
+      https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_view_set_options_statement
+
+4. Added supports `INFORMATION_SCHEMA` views
+    - Document  
+      https://cloud.google.com/bigquery/docs/information-schema-intro
+
+    - Added snippets view names
+
+      |Prefix|Body|
+      |:--|:--|
+      |`informationschemata`|`INFORMATION_SCHEMA.SCHEMATA`|
+      |`informationschemataoptions`|`INFORMATION_SCHEMA.SCHEMATA_OPTIONS`|
+      |`informationtables`|`INFORMATION_SCHEMA.TABLES`|
+      |`informationtableoptions`|`INFORMATION_SCHEMA.TABLE_OPTIONS`|
+      |`informationcolumns`|`INFORMATION_SCHEMA.COLUMNS`|
+      |`informationviews`|`INFORMATION_SCHEMA.VIEWS`|
+
+    - Added snippets view sql
+      - `SELECT ... FROM INFORMATION_SCHEMA.SCHEMATA`
+        - Prefix  
+          `selectinformationschemata`
+        - Body
+          ```sql
+          SELECT
+            catalog_name,
+            schema_name,
+            schema_owner,
+            creation_time,
+            last_modified_time,
+            location
+          FROM
+            `project.INFORMATION_SCHEMA.SCHEMATA`
+          ORDER BY
+            schema_name
+          ```
+      - `SELECT ... FROM INFORMATION_SCHEMA.SCHEMATA_OPTIONS`
+        - Prefix  
+          `selectinformationschemataoptions`
+        - Body
+          ```sql
+          SELECT
+            catalog_name,
+            schema_name,
+            option_name,
+            option_type,
+            option_value
+          FROM
+            `project.INFORMATION_SCHEMA.SCHEMATA_OPTIONS`
+          ORDER BY
+            schema_name, option_name
+          ```
+      - `SELECT ... FROM INFORMATION_SCHEMA.TABLES`
+        - Prefix  
+          `selectinformationtables`
+        - Body
+          ```sql
+          SELECT
+            table_catalog,
+            table_schema,
+            table_name,
+            table_type,
+            is_insertable_into,
+            is_typed,
+            creation_time
+          FROM
+            `project.${2:dataset}.INFORMATION_SCHEMA.TABLES`
+          ORDER BY
+            table_name
+          ```
+      - `SELECT ... FROM INFORMATION_SCHEMA.TABLE_OPTIONS`
+        - Prefix  
+          `selectinformationtableoptions`
+        - Body
+          ```sql
+          SELECT
+            table_catalog,
+            table_schema,
+            table_name,
+            option_name,
+            option_type,
+            option_value
+          FROM
+            `project.dataset.INFORMATION_SCHEMA.TABLE_OPTIONS`
+          ORDER BY
+            table_name, option_name
+          ```
+      - `SELECT ... FROM INFORMATION_SCHEMA.COLUMNS`
+        - Prefix  
+          `selectinformationcolumns`
+        - Body
+          ```sql
+          SELECT
+            table_catalog,
+            table_schema,
+            table_name,
+            column_name,
+            ordinal_position,
+            is_nullable,
+            data_type,
+            is_generated,
+            generation_expression,
+            is_stored,
+            is_hidden,
+            is_updatable,
+            is_system_defined,
+            is_partitioning_column,
+            clustering_ordinal_position
+          FROM
+            `project.dataset.INFORMATION_SCHEMA.COLUMNS`
+          ORDER BY
+            table_name, ordinal_position
+          ```
+      - `SELECT ... FROM INFORMATION_SCHEMA.VIEWS`
+        - Prefix  
+          `selectinformationviews`
+        - Body
+          ```sql
+          SELECT
+            table_catalog,
+            table_schema,
+            table_name,
+            view_definition,
+            check_option,
+            use_standard_sql
+          FROM
+            `project.dataset.INFORMATION_SCHEMA.VIEWS`
+          ORDER BY
+            table_name
+          ```
+
+
 ## 1.0.0
 1. Added supports new function `ML.PREDICT`
   - Supported syntax highlighting
   - Added snippets of `ML.PREDICT` function
       - Prefix  
         `mlpredict`
-      - body
+      - Body
         ```sql
         ML.PREDICT(MODEL `project.dataset.model`,
           {TABLE table_name | (query_statement)},
@@ -21,7 +229,7 @@
   - Snippet supports to addition of standardization parameter.
     - Prefix  
       `mlpredict`
-    - body
+    - Body
       - old
         ```sql
         ML.WEIGHTS(MODEL `project.dataset.model`)
@@ -45,7 +253,7 @@
     - Added snippets of `ML.CONFUSION_MATRIX` function
         - Prefix  
           `mlconfusionmatrix`
-        - body
+        - Body
           ```sql
           ML.CONFUSION_MATRIX(MODEL `project.dataset.model`,
             {TABLE table_name | (query_statement)},
@@ -105,7 +313,7 @@
     - Added snippets of `ML.TRAINING_INFO` function
         - Prefix  
           `mltraininginfo`
-        - body
+        - Body
           ```sql
           ML.TRAINING_INFO(MODEL `project.dataset.model`)
           ```
@@ -114,7 +322,7 @@
     - Added snippets of `ML.FEATURE_INFO` function
         - Prefix  
           `mlfeatureinfo`
-        - body
+        - Body
           ```sql
           ML.FEATURE_INFO(MODEL `project.dataset.model`)
           ```
@@ -123,7 +331,7 @@
     - Added snippets of `ML.WEIGHTS` function
         - Prefix  
           `mlweights`
-        - body
+        - Body
           ```sql
           ML.WEIGHTS(MODEL `project.dataset.model`)
           ```
@@ -140,7 +348,7 @@
     - Added snippets of `CREATE MODEL` statement
         - Prefix  
           `create model`
-        - body
+        - Body
           ```sql
           CREATE MODEL | CREATE MODEL IF NOT EXISTS | CREATE OR REPLACE MODEL `project.dataset.model`
           [OPTIONS(model_option_list)]
@@ -149,7 +357,7 @@
     - Added snippets of `ML.EVALUATE` function
         - Prefix  
           `mlevaluate`
-        - body
+        - Body
           ```sql
           ML.EVALUATE(MODEL `project.dataset.model`,
             {TABLE table_name | (query_statement)},
@@ -158,7 +366,7 @@
     - Added snippets of `ML.ROC_CURVE` function
         - Prefix  
           `mlroccurve`
-        - body
+        - Body
           ```sql
           ML.ROC_CURVE(MODEL `project.dataset.model`,
             {TABLE table_name | (query_statement)},
@@ -174,7 +382,7 @@
         - JavaScript UDF
             - Prefix  
               `create function javascript`
-            - body
+            - Body
               ```sql
               CREATE TEMPORARY FUNCTION functionName(param_name param_type[, ...])
               RETURNS data_type
@@ -185,7 +393,7 @@
         - SQL UDF
             - Prefix  
               `create function sql`
-            - body
+            - Body
               ```sql
               CREATE TEMPORARY FUNCTION functionName(param_name param_type[, ...])
               [RETURNS data_type]
@@ -287,7 +495,7 @@
     - Snippet
         - Prefix  
           `create table as select`
-        - body  
+        - Body  
           ```sql
           CREATE TABLE `project.dataset.table`
           (
@@ -305,9 +513,9 @@
 
     - Snippet
         - Prefix
-              - `create table options`
-              - `options`
-        - body
+            - `create table options`
+            - `options`
+        - Body
           ```sql
           OPTIONS (
             description = "description",
@@ -333,7 +541,7 @@
     - Snippet
         - Prefix  
           `merge`
-        - body
+        - Body
           ```sql
           MERGE INTO target_name t
           USING source_name s

--- a/grammars/sql-bigquery.cson
+++ b/grammars/sql-bigquery.cson
@@ -39,7 +39,7 @@
         'name': 'entity.name.function.sql'
       '6':
         'name': 'invalid.illegal.table.delimiter.sql'
-    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?|drop)\\s+(table|view|model)\\b(?:\\s+(if(?:\\s+not)?\\s+exists)\\b)?)(?:\\s+(`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}\\*]+)\\4)?'
+    'match': '(?i:^\\s*(create(?:\\s+or\\s+replace)?|drop|alter)\\s+(table|view|model)\\b(?:\\s+(if(?:\\s+not)?\\s+exists)\\b)?)(?:\\s+(`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}\\*]+)\\4)?'
     'name': 'meta.create.sql'
   }
   {
@@ -82,7 +82,7 @@
         'name': 'invalid.illegal.table.delimiter.sql'
       '9':
         'name': 'variable.parameter.table.legacy.sql'
-    'match': '(?i)(from|join|delete\\s+from|delete(?!\\s+from)|update|using)\\s+((`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\3?|\\[((?:[\\w\\-\\{\\}]+(?:\\:|(\\.)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\])'
+    'match': '(?i)(from|join|delete\\s+from|delete(?!\\s+from)|update|using)\\s+((`?)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?(?:INFORMATION_SCHEMA\\.\\w+|[\\w\\{\\}]+))(\\*|\\$\\w+)?\\3?|\\[((?:[\\w\\-\\{\\}]+(?:\\:|(\\.)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\])'
     'name': 'meta.create.from.sql'
   }
   {
@@ -112,7 +112,7 @@
         'name': 'invalid.illegal.table.delimiter.sql'
       '7':
         'name': 'variable.parameter.table.legacy.sql'
-    'match': '^\\s*(?:(`)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\1|\\[((?:[\\w\\-\\{\\}]+(?:\\:|(\\.)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\])'
+    'match': '^\\s*(?:(`)((?:[\\w\\-\\{\\}]+(?:\\.|(\\:)))?(?:[\\w\\{\\}]+\\.)?(?:INFORMATION_SCHEMA\\.\\w+|[\\w\\{\\}]+))(\\*|\\$\\w+)?\\1|\\[((?:[\\w\\-\\{\\}]+(?:\\:|(\\.)))?(?:[\\w\\{\\}]+\\.)?[\\w\\{\\}]+)(\\*|\\$\\w+)?\\])'
     'name': 'meta.other.table.sql'
   }
   {

--- a/snippets/language-sql-bigquery.cson
+++ b/snippets/language-sql-bigquery.cson
@@ -64,6 +64,13 @@
 
     """
 
+  '_TABLE_SUFFIX BETWEEN ...':
+    'prefix': '_tablesuffix'
+    'body': '_TABLE_SUFFIX BETWEEN "${1:from}" AND "${2:to}"'
+  '_TABLE_SUFFIX BETWEEN ..':
+    'prefix': 'tablesuffix'
+    'body': '_TABLE_SUFFIX BETWEEN "${1:from}" AND "${2:to}"'
+
   '_PARTITIONTIME BETWEEN ...':
     'prefix': '_partitiontime'
     'body': '_PARTITIONTIME BETWEEN "${1:yyyy-mm-dd}" AND "${2:yyyy-mm-dd}"'
@@ -271,6 +278,58 @@
     'prefix': 'drop view if exists'
     'body': """
       DROP VIEW IF EXISTS `${1:project}.${2:dataset}.${3:view}`
+    """
+
+  'ALTER TABLE SET OPTIONS':
+    'prefix': 'altertable'
+    'body': """
+      ALTER TABLE `${1:project}.${2:dataset}.${3:table}`
+      SET OPTIONS (
+      \tdescription = "description",
+      \texpiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+      \tpartition_expiration_days = 1,
+      \trequire_partition_filter = false,
+      \tkms_key_name = "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]",
+      \tfriendly_name = "friendly_name",
+      \tlabels = [("key", "value")]
+      )
+    """
+  'ALTER TABLE IF EXISTS SET OPTIONS':
+    'prefix': 'altertableifexists'
+    'body': """
+      ALTER TABLE IF EXISTS `${1:project}.${2:dataset}.${3:table}`
+      SET OPTIONS (
+      \tdescription = "description",
+      \texpiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+      \tpartition_expiration_days = 1,
+      \trequire_partition_filter = false,
+      \tkms_key_name = "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]",
+      \tfriendly_name = "friendly_name",
+      \tlabels = [("key", "value")]
+      )
+    """
+
+  'ALTER VIEW SET OPTIONS':
+    'prefix': 'alterview'
+    'body': """
+      ALTER VIEW `${1:project}.${2:dataset}.${3:view}`
+      SET OPTIONS (
+      \tdescription = "description",
+      \texpiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+      \tfriendly_name = "friendly_name",
+      \tlabels = [("key", "value")]
+      )
+    """
+  'ALTER VIEW IF EXISTS SET OPTIONS':
+    'prefix': 'alterviewifexists'
+    'body': """
+      ALTER VIEW IF EXISTS `${1:project}.${2:dataset}.${3:view}`
+      SET OPTIONS (
+      \tdescription = "description",
+      \texpiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
+      \tfriendly_name = "friendly_name",
+      \tlabels = [("key", "value")]
+      )
     """
 
   'CAST()':
@@ -2197,3 +2256,168 @@
   'ST_UNION_AGG()':
     'prefix': 'stunionagg'
     'body': 'ST_UNION_AGG(${1:geography})'
+
+  'INFORMATION_SCHEMA.SCHEMATA':
+    'prefix': 'informationschemata'
+    'body': 'INFORMATION_SCHEMA.SCHEMATA'
+    'description': """
+      When you query the INFORMATION_SCHEMA.SCHEMATA view, the query results contain one row for each dataset in a project to which the current user has access.
+    """
+
+  'INFORMATION_SCHEMA.SCHEMATA_OPTIONS':
+    'prefix': 'informationschemataoptions'
+    'body': 'INFORMATION_SCHEMA.SCHEMATA_OPTIONS'
+    'description': """
+      When you query the INFORMATION_SCHEMA.SCHEMATA_OPTIONS view, the query results contain one row for each dataset in a project to which the current user has access.
+    """
+
+  'INFORMATION_SCHEMA.TABLES':
+    'prefix': 'informationtables'
+    'body': 'INFORMATION_SCHEMA.TABLES'
+    'description': """
+      When you query the INFORMATION_SCHEMA.TABLES view, the query results contain one row for each table or view in a dataset.
+    """
+
+  'INFORMATION_SCHEMA.TABLE_OPTIONS':
+    'prefix': 'informationtableoptions'
+    'body': 'INFORMATION_SCHEMA.TABLE_OPTIONS'
+    'description': """
+      When you query the INFORMATION_SCHEMA.TABLE_OPTIONS view, the query results contain one row for each table or view in a dataset.
+    """
+
+  'INFORMATION_SCHEMA.COLUMNS':
+    'prefix': 'informationcolumns'
+    'body': 'INFORMATION_SCHEMA.COLUMNS'
+    'description': """
+      When you query the INFORMATION_SCHEMA.COLUMNS view, the query results contain one row for each column (field) in a table.
+    """
+
+  'INFORMATION_SCHEMA.VIEWS':
+    'prefix': 'informationviews'
+    'body': 'INFORMATION_SCHEMA.VIEWS'
+    'description': """
+      When you query the INFORMATION_SCHEMA.VIEWS view, the query results contain one row for each view in a dataset.
+    """
+
+  'SELECT ... FROM INFORMATION_SCHEMA.SCHEMATA':
+    'prefix': 'selectinformationschemata'
+    'body': """
+      SELECT
+      \tcatalog_name,
+      \tschema_name,
+      \tschema_owner,
+      \tcreation_time,
+      \tlast_modified_time,
+      \tlocation
+      FROM
+      \t`${1:project}.INFORMATION_SCHEMA.SCHEMATA`
+      ORDER BY
+      \tschema_name
+    """
+    'description': """
+      When you query the INFORMATION_SCHEMA.SCHEMATA view, the query results contain one row for each dataset in a project to which the current user has access.
+    """
+
+  'SELECT ... FROM INFORMATION_SCHEMA.SCHEMATA_OPTIONS':
+    'prefix': 'selectinformationschemataoptions'
+    'body': """
+      SELECT
+      \tcatalog_name,
+      \tschema_name,
+      \toption_name,
+      \toption_type,
+      \toption_value
+      FROM
+      \t`${1:project}.INFORMATION_SCHEMA.SCHEMATA_OPTIONS`
+      ORDER BY
+      \tschema_name, option_name
+    """
+    'description': """
+      When you query the INFORMATION_SCHEMA.SCHEMATA_OPTIONS view, the query results contain one row for each dataset in a project to which the current user has access.
+    """
+
+  'SELECT ... FROM INFORMATION_SCHEMA.TABLES':
+    'prefix': 'selectinformationtables'
+    'body': """
+      SELECT
+      \ttable_catalog,
+      \ttable_schema,
+      \ttable_name,
+      \ttable_type,
+      \tis_insertable_into,
+      \tis_typed,
+      \tcreation_time
+      FROM
+      \t`${1:project}.${2:dataset}.INFORMATION_SCHEMA.TABLES`
+      ORDER BY
+      \ttable_name
+    """
+    'description': """
+      When you query the INFORMATION_SCHEMA.TABLES view, the query results contain one row for each table or view in a dataset.
+    """
+
+  'SELECT ... FROM INFORMATION_SCHEMA.TABLE_OPTIONS':
+    'prefix': 'selectinformationtableoptions'
+    'body': """
+      SELECT
+      \ttable_catalog,
+      \ttable_schema,
+      \ttable_name,
+      \toption_name,
+      \toption_type,
+      \toption_value
+      FROM
+      \t`${1:project}.${2:dataset}.INFORMATION_SCHEMA.TABLE_OPTIONS`
+      ORDER BY
+      \ttable_name, option_name
+    """
+    'description': """
+      When you query the INFORMATION_SCHEMA.TABLE_OPTIONS view, the query results contain one row for each table or view in a dataset.
+    """
+
+  'SELECT ... FROM INFORMATION_SCHEMA.COLUMNS':
+    'prefix': 'selectinformationcolumns'
+    'body': """
+      SELECT
+      \ttable_catalog,
+      \ttable_schema,
+      \ttable_name,
+      \tcolumn_name,
+      \tordinal_position,
+      \tis_nullable,
+      \tdata_type,
+      \tis_generated,
+      \tgeneration_expression,
+      \tis_stored,
+      \tis_hidden,
+      \tis_updatable,
+      \tis_system_defined,
+      \tis_partitioning_column,
+      \tclustering_ordinal_position
+      FROM
+      \t`${1:project}.${2:dataset}.INFORMATION_SCHEMA.COLUMNS`
+      ORDER BY
+      \ttable_name, ordinal_position
+    """
+    'description': """
+      When you query the INFORMATION_SCHEMA.COLUMNS view, the query results contain one row for each column (field) in a table.
+    """
+
+  'SELECT ... FROM INFORMATION_SCHEMA.VIEWS':
+    'prefix': 'selectinformationviews'
+    'body': """
+      SELECT
+      \ttable_catalog,
+      \ttable_schema,
+      \ttable_name,
+      \tview_definition,
+      \tcheck_option,
+      \tuse_standard_sql
+      FROM
+      \t`${1:project}.${2:dataset}.INFORMATION_SCHEMA.VIEWS`
+      ORDER BY
+      \ttable_name
+    """
+    'description': """
+      When you query the INFORMATION_SCHEMA.VIEWS view, the query results contain one row for each view in a dataset.
+    """


### PR DESCRIPTION
### Requirements

1. Added supports `_TABLE_SUFFIX`
2. Added supports `ALTER TABLE SET OPTIONS` statement
3. Added supports `ALTER VIEW SET OPTIONS` statement
4. Added supports `INFORMATION_SCHEMA` views

### Description of the Change

1. Added supports `_TABLE_SUFFIX`
    - Snippet
        - Prefix
            - `_table_suffix`
            - `table_suffix`
        - Body
          ```sql
          _TABLE_SUFFIX BETWEEN "${1:from}" AND "${2:to}"
          ```
    - Document  
      https://cloud.google.com/bigquery/docs/querying-wildcard-tables

2. Added supports `ALTER TABLE SET OPTIONS` statement
    - Snippet - `ALTER TABLE SET OPTIONS`
        - Prefix  
          `altertable`
        - Body
          ```sql
          ALTER TABLE `${1:project}.${2:dataset}.${3:table}`
          SET OPTIONS (
            description = "description",
            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
            partition_expiration_days = 1,
            require_partition_filter = false,
            kms_key_name = "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]",
            friendly_name = "friendly_name",
            labels = [("key", "value")]
          )
          ```
    - Snippet - `ALTER TABLE IF EXISTS SET OPTIONS`
        - Prefix  
          `altertableifexists`
        - Body
          ```sql
          ALTER TABLE IF EXISTS `${1:project}.${2:dataset}.${3:table}`
          SET OPTIONS (
            description = "description",
            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
            partition_expiration_days = 1,
            require_partition_filter = false,
            kms_key_name = "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]",
            friendly_name = "friendly_name",
            labels = [("key", "value")]
          )
          ```
    - Document  
      https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_set_options_statement

3. Added supports `ALTER VIEW SET OPTIONS` statement
    - Snippet - `ALTER VIEW SET OPTIONS`
        - Prefix  
          `alterview`
        - Body
          ```sql
          ALTER VIEW `${1:project}.${2:dataset}.${3:view}`
          SET OPTIONS (
            description = "description",
            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
            friendly_name = "friendly_name",
            labels = [("key", "value")]
          )
          ```
    - Snippet - `ALTER VIEW IF EXISTS SET OPTIONS`
        - Prefix  
          `alterviewifexists`
        - Body
          ```sql
          ALTER VIEW IF EXISTS `${1:project}.${2:dataset}.${3:view}`
          SET OPTIONS (
            description = "description",
            expiration_timestamp = TIMESTAMP "YYYY-MM-DD HH:MI:SS UTC",
            friendly_name = "friendly_name",
            labels = [("key", "value")]
          )
          ```
    - Document  
      https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_view_set_options_statement

4. Added supports `INFORMATION_SCHEMA` views
    - Document  
      https://cloud.google.com/bigquery/docs/information-schema-intro

    - Added snippets view names

      |Prefix|Body|
      |:--|:--|
      |`informationschemata`|`INFORMATION_SCHEMA.SCHEMATA`|
      |`informationschemataoptions`|`INFORMATION_SCHEMA.SCHEMATA_OPTIONS`|
      |`informationtables`|`INFORMATION_SCHEMA.TABLES`|
      |`informationtableoptions`|`INFORMATION_SCHEMA.TABLE_OPTIONS`|
      |`informationcolumns`|`INFORMATION_SCHEMA.COLUMNS`|
      |`informationviews`|`INFORMATION_SCHEMA.VIEWS`|

    - Added snippets view sql
      - `SELECT ... FROM INFORMATION_SCHEMA.SCHEMATA`
        - Prefix  
          `selectinformationschemata`
        - Body
          ```sql
          SELECT
            catalog_name,
            schema_name,
            schema_owner,
            creation_time,
            last_modified_time,
            location
          FROM
            `project.INFORMATION_SCHEMA.SCHEMATA`
          ORDER BY
            schema_name
          ```
      - `SELECT ... FROM INFORMATION_SCHEMA.SCHEMATA_OPTIONS`
        - Prefix  
          `selectinformationschemataoptions`
        - Body
          ```sql
          SELECT
            catalog_name,
            schema_name,
            option_name,
            option_type,
            option_value
          FROM
            `project.INFORMATION_SCHEMA.SCHEMATA_OPTIONS`
          ORDER BY
            schema_name, option_name
          ```
      - `SELECT ... FROM INFORMATION_SCHEMA.TABLES`
        - Prefix  
          `selectinformationtables`
        - Body
          ```sql
          SELECT
            table_catalog,
            table_schema,
            table_name,
            table_type,
            is_insertable_into,
            is_typed,
            creation_time
          FROM
            `project.${2:dataset}.INFORMATION_SCHEMA.TABLES`
          ORDER BY
            table_name
          ```
      - `SELECT ... FROM INFORMATION_SCHEMA.TABLE_OPTIONS`
        - Prefix  
          `selectinformationtableoptions`
        - Body
          ```sql
          SELECT
            table_catalog,
            table_schema,
            table_name,
            option_name,
            option_type,
            option_value
          FROM
            `project.dataset.INFORMATION_SCHEMA.TABLE_OPTIONS`
          ORDER BY
            table_name, option_name
          ```
      - `SELECT ... FROM INFORMATION_SCHEMA.COLUMNS`
        - Prefix  
          `selectinformationcolumns`
        - Body
          ```sql
          SELECT
            table_catalog,
            table_schema,
            table_name,
            column_name,
            ordinal_position,
            is_nullable,
            data_type,
            is_generated,
            generation_expression,
            is_stored,
            is_hidden,
            is_updatable,
            is_system_defined,
            is_partitioning_column,
            clustering_ordinal_position
          FROM
            `project.dataset.INFORMATION_SCHEMA.COLUMNS`
          ORDER BY
            table_name, ordinal_position
          ```
      - `SELECT ... FROM INFORMATION_SCHEMA.VIEWS`
        - Prefix  
          `selectinformationviews`
        - Body
          ```sql
          SELECT
            table_catalog,
            table_schema,
            table_name,
            view_definition,
            check_option,
            use_standard_sql
          FROM
            `project.dataset.INFORMATION_SCHEMA.VIEWS`
          ORDER BY
            table_name
          ```

### Applicable Issues

- fix #41 - Add support 'INFORMATION_SCHEMA' views
- fix #42 - Add support 'ALTER TABLE' statements
- fix #43 - Add snippet '\_TABLE_SUFFIX' pseudo column
